### PR TITLE
Fix embedding retrieval in match creation

### DIFF
--- a/career_platform/app.py
+++ b/career_platform/app.py
@@ -294,7 +294,7 @@ def create_match():
         job_id = request.form['job_id']
         student = Student.query.get(student_id)
         job = Job.query.get(job_id)
-        student_emb = [float(x) for x in (student.embedding or '').split(',') if x]
+        student_emb = get_embedding(student.id) or []
         job_emb = embed_text(job.description)
         score = cosine_similarity(student_emb, job_emb)
         match = Match(student_id=student_id, job_id=job_id, score=score)


### PR DESCRIPTION
## Summary
- use stored embedding from Redis when computing match score

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*