### PR TITLE
Add password reset/update routes and tests

### DIFF
--- a/career_platform/app.py
+++ b/career_platform/app.py
@@ -108,11 +108,49 @@ def login():
         </form>
     ''')
 
+# Simple username based password reset
+@app.route('/forgot-password', methods=['GET', 'POST'])
+def forgot_password():
+    if request.method == 'POST':
+        username = request.form['username']
+        new_password = request.form['password']
+        user = Staff.query.filter_by(username=username).first()
+        if user:
+            user.set_password(new_password)
+            db.session.commit()
+            flash('Password updated')
+            return redirect(url_for('login'))
+        else:
+            flash('User not found')
+    return render_template_string('''
+        <form method="post">
+            Username: <input name="username"><br>
+            New Password: <input name="password" type="password"><br>
+            <input type="submit" value="Reset Password">
+        </form>
+    ''')
+
 @app.route('/logout')
 @login_required
 def logout():
     logout_user()
     return redirect(url_for('login'))
+
+@app.route('/update-password', methods=['GET', 'POST'])
+@login_required
+def update_password():
+    if request.method == 'POST':
+        new_password = request.form['password']
+        current_user.set_password(new_password)
+        db.session.commit()
+        flash('Password updated')
+        return redirect(url_for('index'))
+    return render_template_string('''
+        <form method="post">
+            New Password: <input name="password" type="password"><br>
+            <input type="submit" value="Update Password">
+        </form>
+    ''')
 
 @app.route('/')
 @login_required

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -55,3 +55,49 @@ def test_created_at_defaults(client):
 
         assert s.created_at is not None
         assert m.created_at is not None
+
+
+def test_forgot_password_resets_password(client):
+    # create a user
+    client.post('/register', data={
+        'username': 'reset',
+        'password': 'old',
+        'name': 'Reset User',
+        'school': 'Test'
+    })
+
+    with app.app_context():
+        user = Staff.query.filter_by(username='reset').first()
+        old_hash = user.password_hash
+
+    client.post('/forgot-password', data={
+        'username': 'reset',
+        'password': 'newpass'
+    }, follow_redirects=True)
+
+    with app.app_context():
+        user = Staff.query.filter_by(username='reset').first()
+        assert user.password_hash != old_hash
+        assert user.check_password('newpass')
+
+
+def test_update_password_logged_in(client):
+    client.post('/register', data={
+        'username': 'update',
+        'password': 'old',
+        'name': 'Update User',
+        'school': 'Test'
+    })
+
+    client.post('/login', data={'username': 'update', 'password': 'old'})
+
+    with app.app_context():
+        user = Staff.query.filter_by(username='update').first()
+        old_hash = user.password_hash
+
+    client.post('/update-password', data={'password': 'newpass'}, follow_redirects=True)
+
+    with app.app_context():
+        user = Staff.query.filter_by(username='update').first()
+        assert user.password_hash != old_hash
+        assert user.check_password('newpass')


### PR DESCRIPTION
## Summary
- implement `/forgot-password` for username-based resets
- implement `/update-password` for logged in users
- create corresponding forms in each view
- add tests that ensure password hash updates

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*