### PR TITLE
Add password reset tests and pin deps

### DIFF
--- a/career_platform/app.py
+++ b/career_platform/app.py
@@ -108,6 +108,27 @@ def login():
         </form>
     ''')
 
+# Simple password reset route
+@app.route('/reset_password', methods=['GET', 'POST'])
+def reset_password():
+    if request.method == 'POST':
+        username = request.form['username']
+        new_pw = request.form['password']
+        user = Staff.query.filter_by(username=username).first()
+        if user:
+            user.set_password(new_pw)
+            db.session.commit()
+            flash('Password updated')
+            return redirect(url_for('login'))
+        flash('User not found')
+    return render_template_string('''
+        <form method="post">
+            Username: <input name="username"><br>
+            New Password: <input name="password" type="password"><br>
+            <input type="submit" value="Reset Password">
+        </form>
+    ''')
+
 @app.route('/logout')
 @login_required
 def logout():

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-Flask
-Flask-SQLAlchemy
-Flask-Login
-openai
-werkzeug
-redis
+Flask==2.3.2
+Flask-SQLAlchemy==3.1.1
+Flask-Login==0.6.3
+openai==1.10.0
+Werkzeug==2.3.7
+redis==5.0.1

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -55,3 +55,33 @@ def test_created_at_defaults(client):
 
         assert s.created_at is not None
         assert m.created_at is not None
+
+
+def test_password_reset(client):
+    client.post('/register', data={
+        'username': 'user2',
+        'password': 'old',
+        'name': 'User Two',
+        'school': 'Test'
+    }, follow_redirects=True)
+
+    resp = client.post('/reset_password', data={
+        'username': 'user2',
+        'password': 'new'
+    }, follow_redirects=True)
+    assert b'Password updated' in resp.data
+
+    resp = client.post('/login', data={
+        'username': 'user2',
+        'password': 'new'
+    }, follow_redirects=True)
+    assert b'Logged in as user2' in resp.data
+
+
+def test_template_routes(client):
+    resp = client.get('/register')
+    assert b'Username' in resp.data and b'Password' in resp.data
+    resp = client.get('/login')
+    assert b'Login' in resp.data
+    resp = client.get('/reset_password')
+    assert b'Reset Password' in resp.data


### PR DESCRIPTION
## Summary
- pin Python dependencies in requirements.txt
- add a password reset route
- expand pytest coverage for password resets and template endpoints

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement Flask==2.3.2)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*