### PR TITLE
Add admin promotion script

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,11 @@ If you update the models, delete the existing `career.db` to recreate the schema
 
 
 Student resumes and summaries are stored in the database and `uploads/` folder. Jobs and matches are visible only to authenticated users, with job creation and matching restricted to admins.
+
+## Scripts
+
+Use `promote_admin.py` to grant admin rights to an existing staff account:
+
+```bash
+python scripts/promote_admin.py <username-or-email>
+```

--- a/scripts/promote_admin.py
+++ b/scripts/promote_admin.py
@@ -1,0 +1,27 @@
+from career_platform.app import app, db, Staff
+from sqlalchemy import or_
+import sys
+
+
+def promote(identifier: str) -> None:
+    """Promote a staff user to admin by username or email."""
+    with app.app_context():
+        user = Staff.query.filter(
+            or_(Staff.username == identifier, Staff.email == identifier)
+        ).first()
+        if not user:
+            print(f"User '{identifier}' not found")
+            return
+        if user.is_admin:
+            print(f"User '{identifier}' is already an admin")
+            return
+        user.is_admin = True
+        db.session.commit()
+        print(f"Promoted '{identifier}' to admin")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("Usage: python scripts/promote_admin.py <username-or-email>")
+        sys.exit(1)
+    promote(sys.argv[1])


### PR DESCRIPTION
## Summary
- add a helper script to promote staff to admin
- document the new script in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683a6f8f96048333b7d83485c11f801f