### PR TITLE
Add admin edit/delete routes

### DIFF
--- a/career_platform/forms.py
+++ b/career_platform/forms.py
@@ -41,10 +41,22 @@ class StudentForm(FlaskForm):
     resume = FileField('Resume', validators=[DataRequired()])
     submit = SubmitField('Add')
 
+class EditStudentForm(FlaskForm):
+    name = StringField('Name', validators=[DataRequired()])
+    location = StringField('Location', validators=[DataRequired()])
+    experience = TextAreaField('Experience', validators=[DataRequired()])
+    resume = FileField('Resume')
+    submit = SubmitField('Update')
+
 class JobForm(FlaskForm):
     title = StringField('Title', validators=[DataRequired()])
     description = TextAreaField('Description', validators=[DataRequired()])
     submit = SubmitField('Add Job')
+
+class EditJobForm(FlaskForm):
+    title = StringField('Title', validators=[DataRequired()])
+    description = TextAreaField('Description', validators=[DataRequired()])
+    submit = SubmitField('Update Job')
 
 class MatchForm(FlaskForm):
     student_id = SelectField('Student', coerce=int, validators=[DataRequired()])

--- a/career_platform/templates/dashboard.html
+++ b/career_platform/templates/dashboard.html
@@ -12,13 +12,13 @@
 <h3>Students</h3>
 <ul>
 {% for s in students %}
-    <li>{{ s.name }} - {{ s.summary }}</li>
+    <li>{{ s.name }} - {{ s.summary }}{% if current_user.is_admin %} [<a href="{{ url_for('edit_student', student_id=s.id) }}">edit</a>] [<a href="{{ url_for('delete_student', student_id=s.id) }}">delete</a>]{% endif %}</li>
 {% endfor %}
 </ul>
 <h3>Jobs</h3>
 <ul>
 {% for j in jobs %}
-    <li>{{ j.title }}</li>
+    <li>{{ j.title }}{% if current_user.is_admin %} [<a href="{{ url_for('edit_job', job_id=j.id) }}">edit</a>] [<a href="{{ url_for('delete_job', job_id=j.id) }}">delete</a>]{% endif %}</li>
 {% endfor %}
 </ul>
 <h3>Matches</h3>

--- a/career_platform/templates/edit_job.html
+++ b/career_platform/templates/edit_job.html
@@ -1,0 +1,10 @@
+{% extends 'base.html' %}
+{% block title %}Edit Job{% endblock %}
+{% block content %}
+<form method="post">
+    {{ form.csrf_token }}
+    Title: {{ form.title() }}<br>
+    Description: {{ form.description() }}<br>
+    {{ form.submit() }}
+</form>
+{% endblock %}

--- a/career_platform/templates/edit_student.html
+++ b/career_platform/templates/edit_student.html
@@ -1,0 +1,12 @@
+{% extends 'base.html' %}
+{% block title %}Edit Student{% endblock %}
+{% block content %}
+<form method="post" enctype="multipart/form-data">
+    {{ form.csrf_token }}
+    Name: {{ form.name() }}<br>
+    Location: {{ form.location() }}<br>
+    Experience: {{ form.experience() }}<br>
+    Resume: {{ form.resume() }}<br>
+    {{ form.submit() }}
+</form>
+{% endblock %}

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -168,3 +168,79 @@ def test_update_password_logged_in(client):
         assert user.password_hash != old_hash
         assert user.check_password('newpass')
 
+
+def setup_admin_and_student_job(client):
+    client.post('/register', data={
+        'username': 'admin',
+        'password': 'pass',
+        'first_name': 'Admin',
+        'last_name': 'User',
+        'email': 'admin@example.com',
+        'name': 'Admin',
+        'school': 'SchoolX',
+        'is_admin': 'on'
+    }, follow_redirects=True)
+    client.post('/login', data={'username': 'admin', 'password': 'pass'}, follow_redirects=True)
+    client.post('/jobs/new', data={'title': 'Job1', 'description': 'desc'}, follow_redirects=True)
+    import io
+    client.post('/students/new', data={
+        'name': 'Bob',
+        'location': 'NY',
+        'experience': 'Python',
+        'resume': (io.BytesIO(b'data'), 'resume.txt')
+    }, content_type='multipart/form-data', follow_redirects=True)
+    with app.app_context():
+        student = Student.query.filter_by(name='Bob').first()
+        job = Job.query.filter_by(title='Job1').first()
+    return student, job
+
+
+def test_admin_edit_and_delete(client):
+    student, job = setup_admin_and_student_job(client)
+    client.post(f'/students/{student.id}/edit', data={
+        'name': 'Bob2',
+        'location': 'LA',
+        'experience': 'Go',
+    }, content_type='multipart/form-data', follow_redirects=True)
+    client.post(f'/jobs/{job.id}/edit', data={
+        'title': 'Job2',
+        'description': 'new',
+    }, follow_redirects=True)
+    with app.app_context():
+        student = Student.query.get(student.id)
+        job = Job.query.get(job.id)
+        assert student.name == 'Bob2'
+        assert student.location == 'LA'
+        assert job.title == 'Job2'
+
+    client.get(f'/students/{student.id}/delete', follow_redirects=True)
+    client.get(f'/jobs/{job.id}/delete', follow_redirects=True)
+    with app.app_context():
+        assert Student.query.get(student.id) is None
+        assert Job.query.get(job.id) is None
+
+
+def test_non_admin_cannot_edit_or_delete(client):
+    student, job = setup_admin_and_student_job(client)
+    client.get('/logout')
+    client.post('/register', data={
+        'username': 'user',
+        'password': 'pass',
+        'name': 'User',
+        'school': 'SchoolX'
+    }, follow_redirects=True)
+    client.post('/login', data={'username': 'user', 'password': 'pass'}, follow_redirects=True)
+
+    resp = client.post(f'/students/{student.id}/edit', data={'name': 'X', 'location': 'Y', 'experience': 'Z'}, follow_redirects=True)
+    assert b'Admins only' in resp.data
+    resp = client.get(f'/students/{student.id}/delete', follow_redirects=True)
+    assert b'Admins only' in resp.data
+    resp = client.post(f'/jobs/{job.id}/edit', data={'title': 'X', 'description': 'Y'}, follow_redirects=True)
+    assert b'Admins only' in resp.data
+    resp = client.get(f'/jobs/{job.id}/delete', follow_redirects=True)
+    assert b'Admins only' in resp.data
+
+    with app.app_context():
+        assert Student.query.get(student.id) is not None
+        assert Job.query.get(job.id) is not None
+


### PR DESCRIPTION
## Summary
- support editing and deleting students and jobs
- show edit/delete links on dashboard when admin
- add forms and templates for editing
- test that only admins can edit/delete

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_683a8dca59388333901d6a06308a1021